### PR TITLE
ci(codeql): add CodeQL analysis workflow and badge to README

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,60 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ "master", "dev" ]
+  pull_request:
+    branches: [ "master" ]
+  schedule:
+    - cron: "0 3 * * 1"   # at 03:00 at Monday day
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (Java)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ "java" ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      # CodeQL init + attempt autobuild (Maven projelerinde genelde yeterli)
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # public repo'larda kullanılabilir
+          queries: +security-and-quality
+          build-mode: autobuild
+
+      # Eğer autobuild başarısız olursa Maven ile derlemeyi dene
+      - name: Build with Maven (fallback if autobuild failed)
+        if: ${{ failure() }}
+        run: |
+          mvn -B -DskipTests \
+             -Dspotbugs.skip=true -Dpmd.skip=true -Dcheckstyle.skip=true \
+             package
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FlowSentinel
 
+[![CodeQL](https://github.com/gklp/flow-sentinel/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/gklp/flow-sentinel/actions/workflows/codeql-analysis.yml)
+
 FlowSentinel is a Java-based framework for creating and managing **multi-step flows** in a structured, state-driven way.  
 It allows developers to define flows as JSON, validate each step, enforce navigation rules, and execute them with a framework-independent core engine.
 


### PR DESCRIPTION
- Added GitHub Actions workflow for CodeQL security and quality analysis for Java
- Included CodeQL badge in README.md
- Configured to run on `master` and `dev` branches, pull requests to `master`, and scheduled every Monday at 03:00
- Added fallback Maven build step for cases where autobuild fails during analysis